### PR TITLE
Fix/config

### DIFF
--- a/src/commands/backup.js
+++ b/src/commands/backup.js
@@ -1,14 +1,13 @@
 const { Command, flags } = require('@oclif/command')
 const chalk = require('chalk')
-const Conf = require('conf')
 const fs = require('fs')
 const inquirer = require('inquirer')
 const path = require('path')
 
+const config = require('../config')
 const GithubAPI = require('../lib/github-api')
 const Git = require('../lib/git')
 
-const config = new Conf()
 const backupPath = path.join(process.cwd(), `gbulk-backup-${Date.now()}`)
 
 class BackupCommand extends Command {

--- a/src/commands/backup.js
+++ b/src/commands/backup.js
@@ -101,7 +101,7 @@ Scopes needed are : {bold public_repo} or {bold repo}.`
 
     const auth = config.get('auth')
 
-    if (!auth.token) {
+    if (!auth || !auth.token) {
       this.error(chalk`You are not authenticated, please run {yellow gbulk login} first.`)
     } else {
       this.debug('authenticated user is', auth.user)

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -25,7 +25,7 @@ Each command needs access to different scopes, see individual command help secti
 
     const auth = config.get('auth')
 
-    if (auth.user) {
+    if (auth && auth.user) {
       const { confirm } = await inquirer.prompt([
         {
           type: 'list',
@@ -67,7 +67,10 @@ Each command needs access to different scopes, see individual command help secti
     } catch (err) {
       config.set('auth', {})
 
-      this.warn(`${auth.user} was logged out`)
+      if (auth && auth.user) {
+        this.warn(`${auth.user} was logged out`)
+      }
+
       this.error(err)
     }
   }

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -1,11 +1,9 @@
 const { Command, flags } = require('@oclif/command')
 const chalk = require('chalk')
-const Conf = require('conf')
 const inquirer = require('inquirer')
 
+const config = require('../config')
 const GithubAPI = require('../lib/github-api')
-
-const config = new Conf()
 
 class LoginCommand extends Command {
   static description = chalk`login to Github

--- a/src/commands/logout.js
+++ b/src/commands/logout.js
@@ -1,8 +1,7 @@
 const { Command, flags } = require('@oclif/command')
 const chalk = require('chalk')
-const Conf = require('conf')
 
-const config = new Conf()
+const config = require('../config')
 
 class LogoutCommand extends Command {
   static description = `logout from Github

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,7 @@
+const Conf = require('conf')
+
+const config = new Conf({
+  projectName: 'gbulk'
+})
+
+module.exports = config


### PR DESCRIPTION
This fixes the following [`conf`](https://github.com/sindresorhus/conf#readme) error :

```shell
Error: Project name could not be inferred. Please specify the `projectName` option.
```

It also adds better error-safe checks of config values.