### PR TITLE
Prepare v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -350,9 +350,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.8.tgz",
-      "integrity": "sha512-U1bQiWbln41Yo6EeHMr+34aUhvrMVyrhn9lYfPSpLTCrZlGxU4Rtn1bocX+0p2Fc/Jkd2FanCEXdw0WNfHHM0w==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.9.tgz",
+      "integrity": "sha512-NeXgZj+MFL4izGqA4sapdYzkzQG+MtGra9vhQ58dnmDY++VgJaRUws+aLVV5zRJCYJl/8s9IjMmhiUw1WsKSmw==",
       "dev": true
     },
     "@types/events": {
@@ -391,9 +391,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
-      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==",
+      "version": "13.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.1.tgz",
+      "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA==",
       "dev": true
     },
     "@types/sinon": {
@@ -413,6 +413,19 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
       "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
+    },
+    "aigle": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/aigle/-/aigle-1.14.1.tgz",
+      "integrity": "sha512-bCmQ65CEebspmpbWFs6ab3S27TNyVH1b5MledX8KoiGxUhsJmPUUGpaoSijhwawNnq5Lt8jbcq7Z7gUAD0nuTw==",
+      "requires": {
+        "aigle-core": "^1.0.0"
+      }
+    },
+    "aigle-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/aigle-core/-/aigle-core-1.0.0.tgz",
+      "integrity": "sha1-QGbg+aXGCZbYN37RlqIfoXtiUKs="
     },
     "ajv": {
       "version": "6.11.0",
@@ -630,9 +643,9 @@
       "dev": true
     },
     "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
     "clean-regexp": {
@@ -3138,6 +3151,16 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "spinnies": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/spinnies/-/spinnies-0.5.1.tgz",
+      "integrity": "sha512-WpjSXv9NQz0nU3yCT9TFEOfpFrXADY9C5fG6eAJqixLhvTX1jP3w92Y8IE5oafIe42nlF9otjhllnXN/QCaB3A==",
+      "requires": {
+        "chalk": "^2.4.2",
+        "cli-cursor": "^3.0.0",
+        "strip-ansi": "^5.2.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3145,9 +3168,9 @@
       "dev": true
     },
     "stdout-stderr": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/stdout-stderr/-/stdout-stderr-0.1.11.tgz",
-      "integrity": "sha512-JZ2/c/rKXQkvXiH6kgg7kNcw66NNH2U0VK6qomj5fs8Jzs3KtGvX1rzXWPUa4U4OmYJQXkzfHyXC3sPICg04YA==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/stdout-stderr/-/stdout-stderr-0.1.13.tgz",
+      "integrity": "sha512-Xnt9/HHHYfjZ7NeQLvuQDyL1LnbsbddgMFKCuaQKwGCdJm8LnstZIXop+uOY36UR1UXXoHXfMbC1KlVdVd2JLA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "debug": "4.1.1",
     "execa": "4.0.0",
     "inquirer": "7.0.4",
-    "node": "12.14.1"
+    "node": "12.14.1",
+    "spinnies": "0.5.1"
   },
   "devDependencies": {
     "@oclif/dev-cli": "1.22.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@oclif/plugin-help": "2.2.3",
     "@oclif/plugin-not-found": "1.2.3",
     "@oclif/plugin-warn-if-update-available": "1.7.0",
+    "aigle": "1.14.1",
     "axios": "0.19.2",
     "conf": "6.2.0",
     "debug": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,11 @@
   ],
   "homepage": "https://github.com/g-script/gbulk",
   "keywords": [
-    "oclif"
+    "oclif",
+    "github",
+    "cli",
+    "bulk",
+    "gbulk"
   ],
   "license": "MIT",
   "main": "src/index.js",

--- a/src/commands/backup.js
+++ b/src/commands/backup.js
@@ -73,7 +73,18 @@ Git LFS objects will be backup if {bold git-lfs} is available in path.`
       char: 'i',
       description: 'interactive mode',
       default: false,
-      exclusive: ['public', 'private', 'owner', 'collaborator', 'member', 'exclude', 'match', 'clean-refs', 'lfs']
+      exclusive: [
+        'public',
+        'private',
+        'owner',
+        'collaborator',
+        'member',
+        'exclude',
+        'match',
+        'clean-refs',
+        'lfs',
+        'quiet'
+      ]
     }),
     parallel: flags.string({
       char: 'p',

--- a/src/commands/backup.js
+++ b/src/commands/backup.js
@@ -4,11 +4,13 @@ const chalk = require('chalk')
 const fs = require('fs')
 const inquirer = require('inquirer')
 const path = require('path')
+const Spinnies = require('spinnies')
 
 const config = require('../config')
 const GithubAPI = require('../lib/github-api')
 const Git = require('../lib/git')
 
+const spinnies = new Spinnies()
 const backupPath = path.join(process.cwd(), `gbulk-backup-${Date.now()}`)
 const defaultParallelCount = 8
 
@@ -216,7 +218,9 @@ Git LFS objects will be backup if {bold git-lfs} is available in path.`
 
     // If `from` equals authenticated user, use it as backup source (not as another user)
     if (args.from === auth.user) {
-      !flags.quiet && this.log(`Fetching repositories of ${auth.user}...`)
+      if (!flags.quiet) {
+        spinnies.add('fetch', { text: `Fetching repositories of ${auth.user}` })
+      }
 
       this.debug('backup authenticated user repositories')
 
@@ -252,12 +256,18 @@ Git LFS objects will be backup if {bold git-lfs} is available in path.`
     // - user
     // - organization
 
+    if (!flags.quiet) {
+      spinnies.succeed('fetch')
+    }
+
     if (!repositories.length) {
       this.warn('No repositories to backup.')
 
       exitCode = 1
     } else {
-      this.debug(`${repositories.length} repositories to backup`)
+      if (!flags.quiet) {
+        spinnies.add('prepare', { text: `Preparing backup of ${repositories.length} repositories...` })
+      }
 
       if (flags.exclude) {
         this.debug('filter repos following exclude flag')
@@ -398,7 +408,6 @@ Git LFS objects will be backup if {bold git-lfs} is available in path.`
         }
       }
 
-      !flags.quiet && this.log(`Starting backup of ${repositories.length} repositories...`)
 
       await Promise.all(repositories).mapLimit(flags.parallel, async (repository) => {
         const data = {
@@ -406,12 +415,20 @@ Git LFS objects will be backup if {bold git-lfs} is available in path.`
           url: repository.urls.https
         }
 
+        if (!flags.quiet) {
+          spinnies.add(repository.fullName, { text: `${repository.fullName} ==> Cloning...` })
+        }
+
         try {
-          await Git.clone(data, flags.quiet)
+          await Git.clone(data)
 
           if (flags.lfs && gitLFS) {
+            if (!flags.quiet) {
+              spinnies.update(repository.fullName, { text: `${repository.fullName} ==> Fetching LFS objects...` })
+            }
+
             try {
-              await Git.LFS.fetch(data, flags.quiet)
+              await Git.LFS.fetch(data)
             } catch (err) {
               this.warn(`Failed to fetch LFS objects from ${repository.fullName}`)
               this.debug(err)
@@ -421,7 +438,9 @@ Git LFS objects will be backup if {bold git-lfs} is available in path.`
           }
 
           if (flags['clean-refs']) {
-            this.debug('clean /pull refs')
+            if (!flags.quiet) {
+              spinnies.update(repository.fullName, { text: `${repository.fullName} ==> Cleaning /pull refs...` })
+            }
 
             try {
               await Git.cleanRefs(data)
@@ -432,14 +451,42 @@ Git LFS objects will be backup if {bold git-lfs} is available in path.`
               exitCode = 1
             }
           }
+
+          if (!flags.quiet) {
+            spinnies.succeed(repository.fullName, { text: `${repository.fullName} ===> ${data.path}` })
+            spinnies.update('backup', { text: globalBackupText(++backupCount) })
+
+            if (repositories.length > 25) {
+              setTimeout(() => {
+                spinnies.remove(repository.fullName)
+              }, 5000)
+            }
+          }
         } catch (err) {
           if (err.exitCode === 128) {
-            this.error(`Failed to backup ${repository.fullName}, destination path exists and is not empty`)
+            const error = `${repository.fullName}: destination path exists and is not empty`
+
+            if (!flags.quiet) {
+              spinnies.fail(repository.fullName, {
+                text: error
+              })
+            } else {
+              this.warn(error)
+            }
+          } else {
+            if (!flags.quiet) {
+              spinnies.fail(repository.fullName, { text: err.shortMessage })
+            } else {
+              this.warn(err.shortMessage)
+            }
           }
 
-          this.error(err.shortMessage)
           this.debug(err)
         }
+      })
+
+      if (!flags.quiet) {
+        spinnies.succeed('backup')
       }
     }
 

--- a/src/lib/git.js
+++ b/src/lib/git.js
@@ -25,8 +25,8 @@ const Git = {
    * @returns {void}
    * @throws {Error} `execa` error
    */
-  clone: async function cloneRepository({ path, url }, quiet = false) {
-    await execa('git', ['clone', '--mirror', url, path], !quiet && { stdio: 'inherit' })
+  clone: async function cloneRepository({ path, url }, pipe = false) {
+    await execa('git', ['clone', '--mirror', url, path], pipe && { stdio: 'inherit' })
   },
   /**
    * Delete /pull references from a local repository
@@ -77,8 +77,8 @@ const Git = {
      * @returns {void}
      * @throws {Error} `execa` error
      */
-    fetch: async function fetchLFS({ path }, quiet = false) {
-      await execa('git', ['lfs', 'fetch', '--all'], { cwd: path, stdio: quiet ? 'pipe' : 'inherit' })
+    fetch: async function fetchLFS({ path }, pipe = false) {
+      await execa('git', ['lfs', 'fetch', '--all'], { cwd: path, stdio: pipe ? 'inherit' : 'pipe' })
     }
   }
 }

--- a/src/lib/github-api.js
+++ b/src/lib/github-api.js
@@ -133,9 +133,6 @@ const recurseRepositories = async function({ token, url, params, repositories = 
     debug(`got ${res.data.length} repos`)
 
     repos = res.data.reduce((acc, repo) => {
-      if (/yellowinnovation.fr/.test(repo.full_name)) {
-        console.log(repo)
-      }
       if (repo.permissions && !repo.permissions.pull) {
         debug(`user do not have pull right on repository ${repo.name}, skipping it`)
       } else {


### PR DESCRIPTION
Changelog:
* Fix: remove remaining console.log
* Update: rename Git wrapper `quiet` option to `pipe` on `cloneRepository` and `fetchLFS` functions
* Feature: support parallel backups (enable by default to 8 parallel backup)
* Usage: disallow `quiet` flag with interactive mode
* Feature: add spinners